### PR TITLE
Add What Broke Today to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [VictoriaMetrics](https://victoriametrics.com/blog/proxmox-monitoring-with-dbaas/)
 - [Zabbix](https://www.zabbix.com/de/integrations/proxmox)
 
+- [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator tracking 100+ cloud services with real-time Telegram alerts
 ---
 
 ## Backup Tools


### PR DESCRIPTION
## Summary
- Adds [What Broke Today](https://whatbroke.today) to the Monitoring section

## About What Broke Today
What Broke Today is an AI-powered outage aggregator that:
- Monitors 100+ cloud service status pages in real-time
- Uses AI to filter out maintenance/scheduled updates
- Sends instant alerts via Telegram
- Provides a clean web dashboard for browsing incidents

This tool helps Proxmox operators stay informed about external service dependencies.

## Checklist
- [x] Link is working
- [x] Description follows existing format
- [x] Placed in appropriate section (Monitoring)