### PR TITLE
Add osx-proxmox to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 - [Ansible Module - Proxmox VE Cluster](https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html)
 - [Cluster API Provider for Proxmox VE (CAPMOX)](https://github.com/ionos-cloud/cluster-api-provider-proxmox)
 - [LXC AutoScale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale)
+- [osx-proxmox](https://github.com/lucid-fabrics/osx-proxmox-next) - One-command macOS VM automation for Proxmox 9 with TUI wizard, recovery auto-download, and AMD/Intel support.
 - [proxmox-backup](https://github.com/tis24dev/proxmox-backup)
 - [ProxMenux](https://github.com/MacRimi/ProxMenux)
 - [ProxMigrate](https://github.com/AthenaNetworks/ProxMigrate)


### PR DESCRIPTION
## What is osx-proxmox?

One-command macOS VM automation for Proxmox 9. TUI wizard that handles OpenCore setup, recovery image download, and VM creation — supports Sonoma, Sequoia, and Tahoe on both AMD and Intel CPUs.

## Why add it?

- Automates the most common "how do I run macOS on Proxmox?" question
- Already integrated into [community-scripts/ProxmoxVE](https://github.com/community-scripts/ProxmoxVE) (listed in this repo)
- Active development, Apache 2.0 licensed
- GitHub: https://github.com/lucid-fabrics/osx-proxmox-next