### PR TITLE
Add ProxDeploy to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 - [Proxmox VM Autoscale](https://github.com/fabriziosalmi/proxmox-vm-autoscale)
 - [ProxCLMC](https://github.com/gyptazy/ProxCLMC) — Lightweight tool to determine the maximum CPU compatibility level supported across all nodes in a Proxmox VE cluster.
 - [ProxLB](https://github.com/gyptazy/ProxLB)
+- [ProxDeploy](https://github.com/NordicsSys/proxdeploy) — Production-ready Python CLI to deploy, list, and destroy KVM guests from YAML templates, with cloud-init, SSH provisioning, dry-run, and API retry resilience.
 - [ProxmoxMCP](https://github.com/rodaddy/ProxmoxMCP) - MCP server for Proxmox VE management, enabling AI assistants to control VMs, containers, and cluster resources.
 - [ProxmoxMCP-Plus](https://github.com/rodaddy/ProxmoxMCP-Plus) - Enhanced Proxmox MCP server with advanced virtualization management and full OpenAPI integration.
 - [Proxmox-Enhanced-Configuration-Utility (PECU)](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility)


### PR DESCRIPTION
## Add ProxDeploy

[ProxDeploy](https://github.com/NordicsSys/proxdeploy) is a production-ready Python CLI for deploying, listing, and destroying KVM guests on Proxmox VE using YAML templates.

### Features

- **deploy** / **list** / **destroy** commands for KVM VMs
- Cloud-init support (user, SSH keys, IP config, DNS)
- SSH provisioning (wait for boot, run bash scripts via Paramiko)
- `--dry-run` mode to validate without touching Proxmox
- API resilience with timeouts and exponential backoff retries
- Strict validation of config and templates before any API call
- 53-test pytest suite

### Why it fits this list

It's an open-source, MIT-licensed tool that directly interacts with the Proxmox VE API and solves a common workflow: deploying VMs from code rather than the web UI. It complements existing API clients (like proxmoxer) by providing a ready-to-use CLI layer on top.
