### PR TITLE
Add pve-bindsnap (snapshot LXC containers with bind/device mounts) to Backup Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@
 - [proxmox-backup](https://github.com/tis24dev/proxmox-backup)
 - [CV4PVE-AUTOSNAP](https://github.com/Corsinvest/cv4pve-autosnap)
   - Snapshot automation with policies for Proxmox VE.
+- [pve-bindsnap](https://github.com/bitranox/pve-bindsnap)
+  - Snapshot LXC containers that have bind/device mounts, which stock Proxmox greys out. Can also exclude specific volumes from a snapshot. Works with the GUI, API, pct and cv4pve-autosnap.
 - [PBS_Chunk_Checker](https://github.com/VoltKraft/PBS_Chunk_Checker)
 
 ---


### PR DESCRIPTION
Adds pve-bindsnap to the Backup Tools list.

pve-bindsnap is a small open-source overlay (AGPL-3.0) that lets Proxmox snapshot,
roll back and delete snapshots of LXC containers that have bind or device mounts,
which stock Proxmox greys out. Only the managed volumes go into the snapshot; the
bind/device mounts are skipped and the host data behind them is left untouched. It can
also exclude specific managed volumes from a snapshot (a per-mountpoint opt-in). It
loads underneath the PVE API, so it also works with cv4pve-autosnap unchanged.

Disclosure: I am the author. Repo: https://github.com/bitranox/pve-bindsnap
