### PR TITLE
Add proxmox-ftagent to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@
 - [ProxmoxMCP](https://github.com/rodaddy/ProxmoxMCP) - MCP server for Proxmox VE management, enabling AI assistants to control VMs, containers, and cluster resources.
 - [ProxmoxMCP-Plus](https://github.com/rodaddy/ProxmoxMCP-Plus) - Enhanced Proxmox MCP server with advanced virtualization management and full OpenAPI integration.
 - [Proxmox-Enhanced-Configuration-Utility (PECU)](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility)
+- [proxmox-ftagent](https://github.com/Flowtriq/proxmox-ftagent) — One-command LXC deployment of the Flowtriq DDoS detection agent on Proxmox VE, with automatic dependency and systemd service setup.
 - [Proxmox VE Helper-Scripts](https://github.com/community-scripts/ProxmoxVE)
 - [proxtagger](https://github.com/reginleif88/proxtagger)
 - [PVE-mods](https://github.com/Meliox/PVE-mods)


### PR DESCRIPTION
**What:** Adds [proxmox-ftagent](https://github.com/Flowtriq/proxmox-ftagent) to the **Other Tools** section.

**What it does:** A Proxmox VE helper script that deploys the [Flowtriq DDoS detection agent](https://github.com/Flowtriq/ftagent) as an LXC container with one command. It creates a Debian 12 container, installs all dependencies (Python 3, libpcap, tcpdump), sets up the agent from PyPI, and configures a systemd service with auto-restart.

Built for the [Proxmox VE Helper-Scripts](https://github.com/community-scripts/ProxmoxVE) project convention. MIT licensed, supports ARM64.

- Entry placed alphabetically in the Other Tools section
- Description ends with a period
- Checked for duplicates: not currently listed