### PR TITLE
Add Proxmox VMID Updater to Utilities & Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@
 - [Proxmox Mail Gateway Custom Themes](https://github.com/IgorG1/PMG-Theme)
 - [ProxMox Repo Manager/No-Subscription Script](https://tteck.github.io/Proxmox/)
 - [Proxmox VE Helper-Scripts](https://github.com/community-scripts/ProxmoxVE)
+- [Proxmox VMID Updater](https://github.com/sannier3/proxmox-vmid-updater) - Safely renames QEMU VM and LXC container VMIDs, including configurations, storage volumes, snapshots, backups, HA and firewall resources, with transactional rollback.
 - [pve-disk-shrink](https://github.com/Garfieldttt/pve-disk-shrink) — Dialog-based offline shrinking of Proxmox VE VM disks and LXC volumes (zvol/qcow2/LVM), no live ISO or manual partitioning needed.
 
 ---

--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@
 - [Proxmox Mail Gateway Custom Themes](https://github.com/IgorG1/PMG-Theme)
 - [ProxMox Repo Manager/No-Subscription Script](https://tteck.github.io/Proxmox/)
 - [Proxmox VE Helper-Scripts](https://github.com/community-scripts/ProxmoxVE)
-- [Proxmox VMID Updater](https://github.com/sannier3/proxmox-vmid-updater) - Safely renames QEMU VM and LXC container VMIDs, including configurations, storage volumes, snapshots, backups, HA and firewall resources, with transactional rollback.
 - [pve-disk-shrink](https://github.com/Garfieldttt/pve-disk-shrink) — Dialog-based offline shrinking of Proxmox VE VM disks and LXC volumes (zvol/qcow2/LVM), no live ISO or manual partitioning needed.
+- [Proxmox VMID Updater](https://github.com/sannier3/proxmox-vmid-updater) - Safely renames QEMU VM and LXC container VMIDs, including configurations, storage volumes, snapshots, backups, HA and firewall resources, with transactional rollback.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [[Proxmox VMID Updater](https://github.com/sannier3/proxmox-vmid-updater)](https://github.com/sannier3/proxmox-vmid-updater) to the **Utilities & Scripts** section.

## Why it should be included

Proxmox VMID Updater is an open-source Bash utility that safely renames the VMID of a Proxmox VE QEMU virtual machine or LXC container.

Renaming a VMID manually requires updating multiple related resources. The tool handles:

* QEMU and LXC configuration files
* LVM, ZFS, Ceph/RBD and file-based storage volumes
* Snapshots and saved memory states
* Backup files and backup jobs
* Pools and ACL references
* High-availability resources
* Per-guest firewall files

The operation is transactional. Changes are tracked and automatically rolled back if a step fails, and existing destination resources are never overwritten.

The project supports Proxmox VE 8.x and newer, is documented in English and French, and is distributed under the GNU GPL v3 license.

Disclosure: I am the author of the project.

## Checklist

* [x] I searched the README, issues and previous pull requests for duplicates.
* [x] This pull request contains one suggestion.
* [x] The project links directly to its GitHub repository.
* [x] The entry is placed in the relevant category.
* [x] The description is short and ends with a period.
* [x] The spelling and grammar have been checked.
* [x] The change contains no trailing whitespace.