### PR TITLE
Add lws to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
+- [lws](https://github.com/fabriziosalmi/lws) - Unified CLI for Proxmox, LXC and Docker.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
-- [lws](https://github.com/fabriziosalmi/lws) - Unified CLI for Proxmox, LXC and Docker.
+- [lws](https://github.com/fabriziosalmi/lws) — Unified CLI for Proxmox, LXC, and Docker.
 
 ---
 


### PR DESCRIPTION
This adds [lws](https://github.com/fabriziosalmi/lws) to the Other Tools section.

lws is a unified command-line interface for managing Proxmox VE, LXC, and Docker from a single tool. It is open source (MIT), actively maintained, and has a tagged release (v1.4.1).

The entry is appended at the end of the Other Tools section, and this pull request adds only this one entry.