### PR TITLE
Add Proxmox Cluster Balancer to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
-- [Proxmox Cluster Balancer](https://github.com/fabriziosalmi/proxmox-cluster-balancer) - Balance, scale and migrate LXC containers across Proxmox nodes.
+- [Proxmox Cluster Balancer](https://github.com/fabriziosalmi/proxmox-cluster-balancer) — Balance, scale, and migrate LXC containers across Proxmox VE cluster nodes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
+- [Proxmox Cluster Balancer](https://github.com/fabriziosalmi/proxmox-cluster-balancer) - Balance, scale and migrate LXC containers across Proxmox nodes.
 
 ---
 


### PR DESCRIPTION
This adds [Proxmox Cluster Balancer](https://github.com/fabriziosalmi/proxmox-cluster-balancer) to the Other Tools section.

Proxmox Cluster Balancer balances, scales, and migrates LXC containers across the nodes of a Proxmox VE cluster. It is open source (MIT), actively maintained, and has a tagged release (v1.0.0).

The entry is appended at the end of the Other Tools section, and this pull request adds only this one entry.