### PR TITLE
Add proxxx to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
-- [proxxx](https://github.com/fabriziosalmi/proxxx) - Terminal cockpit for Proxmox VE and PBS: a single static Rust binary with a TUI and CLI, no agent on the cluster.
+- [proxxx](https://github.com/fabriziosalmi/proxxx) — Terminal cockpit for Proxmox VE and PBS: a single static Rust binary with a TUI and CLI, and no agent on the cluster.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
+- [proxxx](https://github.com/fabriziosalmi/proxxx) - Terminal cockpit for Proxmox VE and PBS: a single static Rust binary with a TUI and CLI, no agent on the cluster.
 
 ---
 


### PR DESCRIPTION
This adds [proxxx](https://github.com/fabriziosalmi/proxxx) to the Other Tools section.

proxxx is a terminal cockpit for Proxmox VE and PBS, distributed as a single static Rust binary with both a TUI and a CLI, and it requires no agent on the cluster. It is open source (MIT), actively maintained, and has a tagged release (v0.13.2).

The entry is appended at the end of the Other Tools section, and this pull request adds only this one entry.