### PR TITLE
Add Proxmox LXC AutoScale ML to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
-- [Proxmox LXC AutoScale ML](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml) - Machine-learning driven predictive autoscaling of LXC container resources on Proxmox VE.
+- [Proxmox LXC AutoScale ML](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml) — Machine-learning-driven predictive autoscaling of LXC container resources on Proxmox VE.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ProxSnap](https://github.com/gyptazy/ProxSnap) — Lightweight CLI tool for auditing and cleaning up snapshots across Proxmox VE clusters.
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
+- [Proxmox LXC AutoScale ML](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml) - Machine-learning driven predictive autoscaling of LXC container resources on Proxmox VE.
 
 ---
 


### PR DESCRIPTION
This adds [Proxmox LXC AutoScale ML](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml) to the Other Tools section.

Proxmox LXC AutoScale ML applies machine learning to predictively autoscale LXC container resources on Proxmox VE, complementing rule-based autoscalers with demand forecasting. It is open source (MIT), actively maintained, and has a tagged release (v1.2.0).

The entry is appended at the end of the Other Tools section, and this pull request adds only this one entry.