### PR TITLE
Add pbs-autobackup to Backup Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [pve-bindsnap](https://github.com/bitranox/pve-bindsnap)
   - Snapshot LXC containers that have bind/device mounts, which stock Proxmox greys out. Can also exclude specific volumes from a snapshot. Works with the GUI, API, pct and cv4pve-autosnap.
 - [PBS_Chunk_Checker](https://github.com/VoltKraft/PBS_Chunk_Checker)
+- [pbs-autobackup](https://github.com/ferr079/pbs-autobackup) — Unattended backup cycle for a Proxmox Backup Server that stays powered off: Wake-on-LAN, enable the storage, vzdump every node, prune, garbage-collect, then shut the host back down.
 
 ---
 


### PR DESCRIPTION
Adds [pbs-autobackup](https://github.com/ferr079/pbs-autobackup) to **Backup Tools**.

**I am the author of the project** — self-submission, as invited by CONTRIBUTING.

It covers a case the existing entries don't: a Proxmox Backup Server host that is **powered off most of the time**. One cron entry runs the whole cycle unattended — Wake-on-LAN the host, wait for the PBS API to answer, re-enable the PVE storage, `vzdump --all` on each node in parallel via the API, poll until the tasks finish, prune, garbage-collect, disable the storage again, and shut the host down. The storage is disabled between runs so PVE stops logging connection errors while the machine sleeps.

- MIT, released [v1.0.0](https://github.com/ferr079/pbs-autobackup/releases/tag/v1.0.0)
- ShellCheck CI, `--dry-run` mode, exit codes that distinguish partial from critical failure
- Configuration in an environment file (documented `.example`), multi-node, optional Telegram wrapper
- Bash + `curl` + `python3` only, no agent on the PBS side

Checked against CONTRIBUTING: one suggestion in this PR, appended at the end of its category, description ends with a period, link points to the repository, no trailing whitespace. Searched the README and open pull requests first — no duplicate.
