### PR TITLE
Add homelab-scripts to Utilities & Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@
 - [Proxmox VE Helper-Scripts](https://github.com/community-scripts/ProxmoxVE)
 - [pve-disk-shrink](https://github.com/Garfieldttt/pve-disk-shrink) — Dialog-based offline shrinking of Proxmox VE VM disks and LXC volumes (zvol/qcow2/LVM), no live ISO or manual partitioning needed.
 - [Proxmox VMID Updater](https://github.com/sannier3/proxmox-vmid-updater) - Safely renames QEMU VM and LXC container VMIDs, including configurations, storage volumes, snapshots, backups, HA and firewall resources, with transactional rollback.
+- [homelab-scripts](https://github.com/ferr079/homelab-scripts) — Small shell toolbox for a Proxmox homelab: cluster and container status through the API, TLS expiry checks for services behind a reverse proxy, bulk HTTP availability checks, and a Loki query wrapper.
 
 ---
 


### PR DESCRIPTION
Adds [homelab-scripts](https://github.com/ferr079/homelab-scripts) to **Utilities & Scripts**.

**I am the author** — self-submission, as invited by CONTRIBUTING. Separate from #39, which adds a different project.

Four small POSIX-shell tools that came out of running a 4-node Proxmox cluster:

- `pve-status` — node CPU/RAM/uptime, container listing and per-CT detail, straight from the PVE API (`PVEAuditor` token is enough, it only reads)
- `cert-check` — TLS expiry for services published behind a reverse proxy, SNI-aware, warning threshold and exit codes suited to cron
- `http-check` — bulk availability check with OK/WARN/FAIL per service
- `loki-query` — query wrapper for a central Loki instance

MIT, ShellCheck CI, no dependency beyond `bash`, `curl`, `openssl` and `python3`. Hosts and tokens live in an environment file with a documented `.example`; nothing is hardcoded in the scripts.

Checked against CONTRIBUTING: one suggestion in this PR, appended at the end of its category, description ends with a period, link points to the repository, no trailing whitespace. Searched the README and open pull requests first — no duplicate.
