### PR TITLE
Add valheim-proxmox to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@
 - [Snapbridge](https://github.com/abdoufermat5/snapbridge) - Rust CLI for managing Proxmox snapshots on NetApp ONTAP-backed storage (for both NAS and SAN).
 - [Terraform Provider for Proxmox](https://github.com/bpg/terraform-provider-proxmox)
 - [lws](https://github.com/fabriziosalmi/lws) — Unified CLI for Proxmox, LXC, and Docker.
+- [valheim-proxmox](https://github.com/PawelSzymanski89/valheim-proxmox) — One-command Valheim dedicated server in an LXC, with a web panel for players, bans, worlds, backups and mods.
 
 ---
 


### PR DESCRIPTION
One command on a Proxmox host creates an unprivileged LXC, installs the Valheim dedicated server and a web panel to run it: players online with a live session timer and a login history, admin/ban/allow lists, world switching, upload and download, backup restore, launch settings, and mods installed from a Thunderstore Mod Manager share code.

MIT, tested on Proxmox VE 8.4 with Debian 12 and 13 containers.

I am the author of the project, as the contributing guide asks me to state.